### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if ["$GOPATH" == ""]; then
+if [ "$GOPATH" == "" ]; then
 	export GOPATH="$PWD"
 fi
 


### PR DESCRIPTION
`[` is an extenal shell program, so arguments *must* have spaces after them,
otherwise it will not work.