### PR TITLE
Add Command type to GlobalVars

### DIFF
--- a/src/github.com/Virepri/Shoraldele/GlobalVars/GlobalVars.go
+++ b/src/github.com/Virepri/Shoraldele/GlobalVars/GlobalVars.go
@@ -2,6 +2,10 @@ package GlobalVars
 
 import "sync"
 
+type Command struct {
+	command, args string
+}
+
 var ConfigLocs map[string]string
 var SetupFuncs map[string]func(string) //runs on program startup
 var CmdFuncs map[string]func(string,string)


### PR DESCRIPTION
Helpful if, for example, you want to create a channel to act as a LIFO for your
commands